### PR TITLE
Follow-up on jcelerier with full PATH and dmenu arguments support

### DIFF
--- a/README.org
+++ b/README.org
@@ -12,5 +12,9 @@ main = xmonad $ defaultConfig
         `additionalKeysP`
         [ ("M-b" , spawn "$HOME/bin/dmenu-terminal") ]
 #+END_SRC
+** Hooking it up to i3
+
+    bindsym $mod+t exec bin/dmenu-terminal
+
 ** See also
    This is loosely based off of [[https://github.com/losingkeys/dmenu-web][dmenu-web]]

--- a/README.org
+++ b/README.org
@@ -13,8 +13,9 @@ main = xmonad $ defaultConfig
         [ ("M-b" , spawn "$HOME/bin/dmenu-terminal") ]
 #+END_SRC
 ** Hooking it up to i3
-
-    bindsym $mod+t exec bin/dmenu-terminal
+#+BEGIN_SRC
+  bindsym $mod+t exec bin/dmenu-terminal
+#+END_SRC
 
 ** See also
    This is loosely based off of [[https://github.com/losingkeys/dmenu-web][dmenu-web]]

--- a/dmenu-terminal
+++ b/dmenu-terminal
@@ -1,12 +1,17 @@
-#!/bin/sh
+#!/bin/bash
 
 # use the terminal emulator passed-in, or fall back to terminal variable, urxvt or xterm if installed
 if [ "$#" -ne 1 ]; then
-  TERMINAL="$1"
+  if [ -x "$(command -v -- "$1")" ]; then
+    TERMINAL="$1"
+	shift
+  fi
 fi
 
 if [ ! -x "$TERMINAL" -a -x "$(command -v urxvt)" ]; then
   TERMINAL="$(command -v urxvt)"
+elif [ -x "$(command -v gnome-terminal)" ]; then
+  TERMINAL="$(command -v gnome-terminal)"
 elif [ -x "$(command -v xterm)" ]; then
   TERMINAL="$(command -v xterm)"
 else
@@ -20,13 +25,13 @@ if [ ! -x "$(command -v dmenu)" ]; then
   exit 69
 fi
 
-#FIXME: search multiple directories
-choice=$(ls /usr/bin | dmenu)
+choice=$(compgen -c | dmenu "$@")
 binary=$(awk '{print $1;}' <<< $choice)
+fullpath=$(command -v $choice)
 
-if [ -x "$(command -v $choice)" ]; then
+if [ -x $fullpath ]; then
   #FIXME: Wayland
-  if ldd /usr/bin/$binary | grep libX11 > /dev/null; then
+  if ldd $fullpath | grep libX11 > /dev/null; then
     $choice
   else
     $TERMINAL -e $choice

--- a/dmenu-terminal
+++ b/dmenu-terminal
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# use the terminal emulator passed-in, or fall back to terminal variable, urxvt or xterm if installed
+# use the terminal emulator passed-in, or fall back
 if [ "$#" -ne 1 ]; then
   if [ -x "$(command -v -- "$1")" ]; then
     TERMINAL="$1"
@@ -8,6 +8,7 @@ if [ "$#" -ne 1 ]; then
   fi
 fi
 
+# fall back to terminal variable, urxvt, gnome-terminal, or xterm if installed
 if [ ! -x "$TERMINAL" -a -x "$(command -v urxvt)" ]; then
   TERMINAL="$(command -v urxvt)"
 elif [ -x "$(command -v gnome-terminal)" ]; then
@@ -27,13 +28,13 @@ fi
 
 choice=$(compgen -c | dmenu "$@")
 binary=$(awk '{print $1;}' <<< $choice)
-fullpath=$(command -v $choice)
+fullpath=$(command -v $binary)
 
 if [ -x $fullpath ]; then
   #FIXME: Wayland
   if ldd $fullpath | grep libX11 > /dev/null; then
     $choice
   else
-    $TERMINAL -e $choice
+    $TERMINAL -e "$choice"
   fi
 fi

--- a/dmenu-terminal
+++ b/dmenu-terminal
@@ -1,12 +1,14 @@
 #!/bin/sh
 
-# use the terminal emulator passed-in, or fall back to urxvt or xterm if installed
-terminal="$1"
+# use the terminal emulator passed-in, or fall back to terminal variable, urxvt or xterm if installed
+if [ "$#" -ne 1 ]; then
+  TERMINAL="$1"
+fi
 
-if [ ! -x "$temrinal" -a -x "$(command -v urxvt)" ]; then
-  terminal="$(command -v urxvt)"
+if [ ! -x "$TERMINAL" -a -x "$(command -v urxvt)" ]; then
+  TERMINAL="$(command -v urxvt)"
 elif [ -x "$(command -v xterm)" ]; then
-  terminal="$(command -v xterm)"
+  TERMINAL="$(command -v xterm)"
 else
   echo "Usage: $0 <some-terminal>"
   exit 64
@@ -20,7 +22,13 @@ fi
 
 #FIXME: search multiple directories
 choice=$(ls /usr/bin | dmenu)
+binary=$(awk '{print $1;}' <<< $choice)
 
 if [ -x "$(command -v $choice)" ]; then
-  $terminal -e $choice
+  #FIXME: Wayland
+  if ldd /usr/bin/$binary | grep libX11 > /dev/null; then
+    $choice
+  else
+    $TERMINAL -e $choice
+  fi
 fi


### PR DESCRIPTION
Hey, I know it's been a long time since you've probably even looked at this repository, but, I found it really useful and I'm using it right now. I forked jcelerier's fork and made a few updates. I have a feeling he won't be accepting my pull request, and I also thought the base fork might like these improvements. 
First, since my fork is a fork of his, I thought I'd defend his improvements that caused me to make that decision. Here's my response to the [questions you asked j](https://github.com/losingkeys/dmenu-terminal/pull/1#issuecomment-55413346):
1. Why `$TERMINAL` over `$terminal`? I'm not against it, just curious.
I have no idea, I wondered that myself actually. I think TERMINAL may be an environment variable on some systems based on his comment "fall back to terminal variable"
2. I'm confused about the argv check ([diff](https://github.com/losingkeys/dmenu-terminal/pull/1/files#diff-fd6fe00ea13b72d8ac3616d47a3620e6R4)), shouldn't it be -ge or -eq?
Since argv starts at 1 (the script itself), anything not equal to 1 would more than 1 (arguments).
3. What does [this line](https://github.com/losingkeys/dmenu-terminal/pull/1/files#diff-fd6fe00ea13b72d8ac3616d47a3620e6R25) do? Is it portable?
It is portable since my addition, which defaults to `bash` rather than any `sh`. That is merely taking the first word for the purpose of checking if it runs under X (in case it's multi-word).
4. ... what about programs like gvim ...
Yup! I too noticed the problem with vim and find it unfortunate. However, when I am opening vim I tend to do it through a console anyway because I want to navigate to my source directory. I don't know about you. For me the clutter of extra terminal windows is just a non-starter. I use i3, so those terminals take 1/2 the space on my screen (or I have to shuffle them around, etc), so I find j's fork far superior for that reason. Being able to use one command for all dmenu is really great.

Now on to my improvements to j's. They are enumerated in my [pull request to him](https://github.com/jcelerier/dmenu-terminal/pull/2).
- Full PATH support. I have stuff outside of `/usr/bin` that I use all the time and that was a must for me. I saw your `FIXME` comment so clearly for you too. I just use `compgen -c` to list the commands, so it now gets the full path.
- Support for passing arguments to dmenu (I use cool colors)
- Support for Debian, as you pointed out in (3), which basically just fixes a problem introduced in j's
- Surrounded `$choice` in quotes for multi-word (read: arguments) commands.

Overall I think all these changes together turn it from a nice little tool to a great wrapper that should honestly replace dmenu. I found your script and its forks when I searched for this because I really wanted this (especially for `alsamixer`) and it has helped enourmously.
Thanks.